### PR TITLE
Do not add blank params to tracking url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ pkg/
 tmp/
 /.bundle
 /vendor/bundle
+.idea

--- a/lib/urchin_tracking_module.rb
+++ b/lib/urchin_tracking_module.rb
@@ -15,8 +15,10 @@ class UrchinTrackingModule
 
   def tracking(params=defaults)
     filtered_params(params).inject(@url) do |url,(name,value)|
-      url = add_param(url, "#{name}", value)
-      url = add_param(url, "src", value) if name == :utm_source
+      unless value.nil?
+        url = add_param(url, "#{name}", value)
+        url = add_param(url, "src", value) if name == :utm_source
+      end
       url
     end
   end

--- a/spec/urchin_tracking_module_spec.rb
+++ b/spec/urchin_tracking_module_spec.rb
@@ -22,6 +22,15 @@ describe UrchinTrackingModule do
         expect(uri).to match(/#{tracking_param}=#{params[tracking_param]}/)
       end
     end
+
+    context 'when empty param' do
+      before { params.delete(:utm_content) }
+
+      it 'does not tracked' do
+        uri = subject.tracking(params)
+        expect(uri).not_to match(/utm_content=/)
+      end
+    end
   end
 
   describe '.configure' do

--- a/spec/urchin_tracking_module_spec.rb
+++ b/spec/urchin_tracking_module_spec.rb
@@ -26,7 +26,7 @@ describe UrchinTrackingModule do
     context 'when empty param' do
       before { params.delete(:utm_content) }
 
-      it 'does not tracked' do
+      it 'is not tracked' do
         uri = subject.tracking(params)
         expect(uri).not_to match(/utm_content=/)
       end


### PR DESCRIPTION
It wraps url with all tracking params. I refactored to skip blank ones.
