### PR TITLE
default empty string instead of array for URI.decode_www_form

### DIFF
--- a/lib/urchin_tracking_module.rb
+++ b/lib/urchin_tracking_module.rb
@@ -49,7 +49,7 @@ class UrchinTrackingModule
 
   def url_params(uri)
     # conversion to hash e.g. to get rid of duplicate src params
-    params = URI.decode_www_form(uri.query || [])
+    params = URI.decode_www_form(uri.query || '')
     params.inject(Hash.new) { |h,(k,v)| h.merge(k => v) }
   end
   private :url_params


### PR DESCRIPTION
When we have empty query `URI.decode_www_form` fails with `NoMethodError: undefined method`ascii_only?' for []:Array`.
Because Ruby 2.1 have this code

```
def self.decode_www_form(str, enc=Encoding::UTF_8, separator: '&', use__charset_: false, isindex: false)
    raise ArgumentError, "the input of #{self.name}.#{__method__} must be ASCII only string" unless str.ascii_only?
```

instead of (1.9.3)

```
def self.decode_www_form(str, enc=Encoding::UTF_8)
    return [] if str.empty?
```
